### PR TITLE
feat: add "// sql-format:off" marker to skip formatting a specific block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **FormatSqlTextBlockByAnnotation** / **FormatSqlTextBlockByLanguageInjection**: opt a single block out of formatting with a `// sql-format:off` line comment
+
 ## [2.0.0] - 2026-04-28
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A set of [OpenRewrite](https://docs.openrewrite.org/) recipes for formatting SQL
   - [FormatSqlTextBlockByLanguageInjection](#formatsqltextblockbylanguageinjection)
   - [FormatSqlFile](#formatsqlfile)
 - [Configurable Options](#configurable-options)
+- [Skipping a specific block](#skipping-a-specific-block)
 - [Examples](#examples)
   - [FormatSqlTextBlockByAnnotation example](#formatsqltextblockbyannotation-example)
   - [FormatSqlTextBlockByLanguageInjection example](#formatsqltextblockbylanguageinjection-example)
@@ -58,6 +59,27 @@ The following options are applicable to `FormatSqlTextBlockByAnnotation`, `Forma
 | String  | `indent`          | Optional. The string to be used for indentation.                                                                                                                                                     | `"  "` for 2 spaces <br> `"\t"` for a tab | 4 spaces `"    "` |
 | Integer | `maxColumnLength` | Optional. The maximum length of a line before the formatter tries to break it.                                                                                                              | `100`    | `120` |
 | Boolean | `uppercase`       | Optional. Whether to convert SQL keywords to uppercase (not safe to use when the SQL dialect has case-sensitive identifiers).                                        | `true`   | `false` |
+
+## Skipping a specific block
+
+For the Java Text Block recipes (`FormatSqlTextBlockByAnnotation` and `FormatSqlTextBlockByLanguageInjection`), you can opt a single block out of formatting by adding a `// sql-format:off` line comment next to it. This is useful when, for example, you keep the `// language=sql` marker only for IDE syntax highlighting but do not want the block reformatted.
+
+```java
+// language=sql
+// sql-format:off
+private static final String QUERY = """
+    select * from users where active = true
+    """;
+```
+
+```java
+// sql-format:off
+@Query("""
+    select * from Holiday where year = :year""")
+void findByYear(int year);
+```
+
+The marker is case-insensitive (e.g. `// sql-format:off`) but must otherwise match exactly. For language injection it may appear in any order relative to the `// language=sql` comment. Unlike the IDE convention `// @formatter:off`, it does not require a closing marker - it only affects the block it precedes.
 
 ## Examples
 

--- a/src/main/java/io/github/mhagnumdw/utils/CommentUtils.java
+++ b/src/main/java/io/github/mhagnumdw/utils/CommentUtils.java
@@ -22,12 +22,9 @@ public final class CommentUtils {
     /**
      * Returns {@code true} if any of the given comments is the {@code sql-format:off} opt-out marker.
      *
-     * @param comments the comments to inspect (may be {@code null})
+     * @param comments the comments to inspect (the LST always provides a non-null list)
      */
     public static boolean hasNoFormatComment(List<Comment> comments) {
-        if (comments == null) {
-            return false;
-        }
         for (Comment comment : comments) {
             if (comment instanceof TextComment) {
                 TextComment tc = (TextComment) comment;

--- a/src/main/java/io/github/mhagnumdw/utils/CommentUtils.java
+++ b/src/main/java/io/github/mhagnumdw/utils/CommentUtils.java
@@ -1,0 +1,42 @@
+package io.github.mhagnumdw.utils;
+
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.TextComment;
+
+import java.util.List;
+
+/**
+ * Utility class for analyzing line comments that control SQL formatting.
+ */
+public final class CommentUtils {
+
+    /**
+     * Opt-out marker. When present as a single-line comment near a SQL block, the recipe skips
+     * formatting that block. Matched exactly (case-insensitive).
+     */
+    private static final String NO_FORMAT_MARKER = "sql-format:off";
+
+    private CommentUtils() {
+    }
+
+    /**
+     * Returns {@code true} if any of the given comments is the {@code sql-format:off} opt-out marker.
+     *
+     * @param comments the comments to inspect (may be {@code null})
+     */
+    public static boolean hasNoFormatComment(List<Comment> comments) {
+        if (comments == null) {
+            return false;
+        }
+        for (Comment comment : comments) {
+            if (comment instanceof TextComment) {
+                TextComment tc = (TextComment) comment;
+                if (!tc.isMultiline() && NO_FORMAT_MARKER.equalsIgnoreCase(tc.getText().trim())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/io/github/mhagnumdw/visitors/FormatSqlBlockVisitor.java
+++ b/src/main/java/io/github/mhagnumdw/visitors/FormatSqlBlockVisitor.java
@@ -3,6 +3,8 @@ package io.github.mhagnumdw.visitors;
 import com.github.vertical_blank.sqlformatter.core.FormatConfig;
 import com.github.vertical_blank.sqlformatter.languages.Dialect;
 import io.github.mhagnumdw.processors.Annotations;
+import io.github.mhagnumdw.utils.CommentUtils;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
@@ -26,11 +28,36 @@ public class FormatSqlBlockVisitor extends JavaIsoVisitor<ExecutionContext> {
             return annotation;
         }
 
+        if (hasNoFormatComment(annotation, getCursor())) {
+            return annotation;
+        }
+
         String annotationFQN = type.toString();
 
         return Annotations.getProcessor(annotationFQN)
             .map(p -> p.process(annotation, getCursor(), dialect, formatConfig))
             .orElse(annotation);
+    }
+
+    /**
+     * Checks for the {@code sql-format:off} opt-out marker. The comment may sit either directly on
+     * the annotation or on the enclosing declaration (method, field, class), e.g.:
+     *
+     * <pre>{@code
+     * // sql-format:off
+     * @Query("""...""")
+     * void select();
+     * }</pre>
+     */
+    private static boolean hasNoFormatComment(J.Annotation annotation, Cursor cursor) {
+        if (CommentUtils.hasNoFormatComment(annotation.getPrefix().getComments())) {
+            return true;
+        }
+        Object parent = cursor.getParentTreeCursor().getValue();
+        if (parent instanceof J) {
+            return CommentUtils.hasNoFormatComment(((J) parent).getPrefix().getComments());
+        }
+        return false;
     }
 
 }

--- a/src/main/java/io/github/mhagnumdw/visitors/FormatSqlBlockVisitor.java
+++ b/src/main/java/io/github/mhagnumdw/visitors/FormatSqlBlockVisitor.java
@@ -53,11 +53,10 @@ public class FormatSqlBlockVisitor extends JavaIsoVisitor<ExecutionContext> {
         if (CommentUtils.hasNoFormatComment(annotation.getPrefix().getComments())) {
             return true;
         }
-        Object parent = cursor.getParentTreeCursor().getValue();
-        if (parent instanceof J) {
-            return CommentUtils.hasNoFormatComment(((J) parent).getPrefix().getComments());
-        }
-        return false;
+        // The nearest tree parent of an annotation is always a J node (method, field, class, or an
+        // enclosing annotation), so the cast is safe.
+        J parent = cursor.getParentTreeCursor().getValue();
+        return CommentUtils.hasNoFormatComment(parent.getPrefix().getComments());
     }
 
 }

--- a/src/main/java/io/github/mhagnumdw/visitors/FormatSqlTextBlockVisitor.java
+++ b/src/main/java/io/github/mhagnumdw/visitors/FormatSqlTextBlockVisitor.java
@@ -4,6 +4,7 @@ import static org.openrewrite.java.tree.J.Literal;
 
 import com.github.vertical_blank.sqlformatter.core.FormatConfig;
 import com.github.vertical_blank.sqlformatter.languages.Dialect;
+import io.github.mhagnumdw.utils.CommentUtils;
 import io.github.mhagnumdw.utils.TextBlockUtil;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -34,6 +35,10 @@ public class FormatSqlTextBlockVisitor extends JavaIsoVisitor<ExecutionContext> 
     public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations varDecls, ExecutionContext ctx) {
 
         if (!hasLanguageSqlComment(varDecls)) {
+            return varDecls;
+        }
+
+        if (CommentUtils.hasNoFormatComment(varDecls.getPrefix().getComments())) {
             return varDecls;
         }
 

--- a/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByAnnotationTest.java
+++ b/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByAnnotationTest.java
@@ -508,6 +508,29 @@ class FormatSqlTextBlockByAnnotationTest implements RewriteTest {
         );
     }
 
+    // Opt-out comment sitting directly on the annotation prefix (between two annotations) - does not change
+    @Test
+    void shouldNotFormatWhenNoFormatCommentOnAnnotationPrefix() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.fake.holidays;
+
+                import org.hibernate.annotations.processing.HQL;
+
+                public interface HolidayRepository {
+
+                    @Deprecated
+                    // sql-format:off
+                    @HQL(\"""
+                        select * from Holiday where year = :year\""")
+                    void select();
+                }
+                """
+            )
+        );
+    }
+
     @Test
     void shouldNotChangeUnsupportedAnnotations() {
         rewriteRun(

--- a/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByAnnotationTest.java
+++ b/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByAnnotationTest.java
@@ -438,6 +438,76 @@ class FormatSqlTextBlockByAnnotationTest implements RewriteTest {
             );
     }
 
+    // Opt-out: sql-format:off before the annotation - does not change
+    @Test
+    void shouldNotFormatWhenNoFormatComment() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.fake.holidays;
+
+                import org.hibernate.annotations.processing.HQL;
+
+                public interface HolidayRepository {
+
+                    // sql-format:off
+                    @HQL(\"""
+                        select h.*, c.name as country_name from Holiday h inner join Country c on h.country_id = c.id where h.year = :year and h.name != 'Christmas' order by h.name\""")
+                    void select();
+                }
+                """
+            )
+        );
+    }
+
+    // Opt-out only affects the annotated block it precedes, not sibling blocks
+    @Test
+    void shouldFormatOnlyBlocksWithoutNoFormatComment() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.fake.holidays;
+
+                import jakarta.data.repository.Query;
+
+                public interface HolidayRepository {
+
+                    // sql-format:off
+                    @Query(\"""
+                        select * from Holiday where year = :year\""")
+                    void skipped();
+
+                    @Query(\"""
+                        select * from Holiday where year = :year\""")
+                    void formatted();
+                }
+                """,
+                """
+                package io.github.mhagnumdw.fake.holidays;
+
+                import jakarta.data.repository.Query;
+
+                public interface HolidayRepository {
+
+                    // sql-format:off
+                    @Query(\"""
+                        select * from Holiday where year = :year\""")
+                    void skipped();
+
+                    @Query(\"""
+                        select
+                            *
+                        from
+                            Holiday
+                        where
+                            year = :year\""")
+                    void formatted();
+                }
+                """
+            )
+        );
+    }
+
     @Test
     void shouldNotChangeUnsupportedAnnotations() {
         rewriteRun(

--- a/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByLanguageInjectionTest.java
+++ b/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByLanguageInjectionTest.java
@@ -146,7 +146,7 @@ class FormatSqlTextBlockByLanguageInjectionTest implements RewriteTest {
         );
     }
 
-    // Text Block without comment — does not change
+    // Text Block without comment - does not change
     @Test
     void shouldNotFormatWithoutComment() {
         rewriteRun(
@@ -163,7 +163,7 @@ class FormatSqlTextBlockByLanguageInjectionTest implements RewriteTest {
         );
     }
 
-    // Normal string with // language=sql — does not change
+    // Normal string with // language=sql - does not change
     @Test
     void shouldNotFormatNonTextBlockWithComment() {
         rewriteRun(
@@ -232,7 +232,7 @@ class FormatSqlTextBlockByLanguageInjectionTest implements RewriteTest {
         );
     }
 
-    // Block already formatted — no diff
+    // Block already formatted - no diff
     @Test
     void shouldNotChangeAlreadyFormatted() {
         rewriteRun(
@@ -297,7 +297,116 @@ class FormatSqlTextBlockByLanguageInjectionTest implements RewriteTest {
         );
     }
 
-    // Class outside the filePath — does not change
+    // Opt-out: language=sql present but sql-format:off - does not change
+    @Test
+    void shouldNotFormatWhenNoFormatComment() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    // sql-format:off
+                    private static final String QUERY = \"""
+                        select * from users where active = true\""";
+                }
+                """
+            )
+        );
+    }
+
+    // Opt-out works regardless of comment order
+    @Test
+    void shouldNotFormatWhenNoFormatCommentBeforeLanguage() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // sql-format:off
+                    // language=sql
+                    private static final String QUERY = \"""
+                        select * from users where active = true\""";
+                }
+                """
+            )
+        );
+    }
+
+    // Opt-out marker is case-insensitive
+    @Test
+    void shouldNotFormatWhenNoFormatCommentCaseInsensitive() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    // SQL-FORMAT:OFF
+                    private static final String QUERY = \"""
+                        select * from users where active = true\""";
+                }
+                """
+            )
+        );
+    }
+
+    // Opt-out marker must match exactly - extra spaces are not recognized, so the block is formatted
+    @Test
+    void shouldFormatWhenNoFormatCommentHasExtraSpaces() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    // sql-format : off
+                    private static final String QUERY = \"""
+                        select * from users where active = true\""";
+                }
+                """,
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    // sql-format : off
+                    private static final String QUERY = \"""
+                        select
+                            *
+                        from
+                            users
+                        where
+                            active = true\""";
+                }
+                """
+            )
+        );
+    }
+
+    // sql-format:off without language=sql is irrelevant - still nothing to format
+    @Test
+    void shouldNotFormatNoFormatCommentWithoutLanguage() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // sql-format:off
+                    private static final String QUERY = \"""
+                        select * from users where active = true\""";
+                }
+                """
+            )
+        );
+    }
+
+    // Class outside the filePath - does not change
     @Test
     void shouldNotChangeUnrelatedClasses() {
         rewriteRun(

--- a/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByLanguageInjectionTest.java
+++ b/src/test/java/io/github/mhagnumdw/recipes/FormatSqlTextBlockByLanguageInjectionTest.java
@@ -406,6 +406,74 @@ class FormatSqlTextBlockByLanguageInjectionTest implements RewriteTest {
         );
     }
 
+    // A multiline block comment is not the opt-out marker, so the block is still formatted
+    @Test
+    void shouldFormatWithAdjacentMultilineComment() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    /* just a note, not a marker */
+                    private static final String QUERY = \"""
+                        select * from users where active = true\""";
+                }
+                """,
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    /* just a note, not a marker */
+                    private static final String QUERY = \"""
+                        select
+                            *
+                        from
+                            users
+                        where
+                            active = true\""";
+                }
+                """
+            )
+        );
+    }
+
+    // A Javadoc comment is not a line comment, so it is ignored and the block is still formatted
+    @Test
+    void shouldFormatWithAdjacentJavadocComment() {
+        rewriteRun(
+            java(
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    /** Javadoc note, not a marker */
+                    private static final String QUERY = \"""
+                        select * from users where active = true\""";
+                }
+                """,
+                """
+                package io.github.mhagnumdw.test;
+
+                public class MyQuery {
+                    // language=sql
+                    /** Javadoc note, not a marker */
+                    private static final String QUERY = \"""
+                        select
+                            *
+                        from
+                            users
+                        where
+                            active = true\""";
+                }
+                """
+            )
+        );
+    }
+
     // Class outside the filePath - does not change
     @Test
     void shouldNotChangeUnrelatedClasses() {


### PR DESCRIPTION
The FormatSqlTextBlockByAnnotation and FormatSqlTextBlockByLanguageInjection recipes now skip any Text Block preceded by a `// sql-format:off` line comment - useful when `// language=sql` is kept only for IDE syntax highlighting.

The marker is case-insensitive but matched exactly, requires no closing marker, and affects only the block it precedes.